### PR TITLE
fix bug of archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .SUFFIXES:
-.PHONY: default clean cleanall
+.PHONY: default clean cleanall install
 
 default:
 	@:
@@ -49,3 +49,5 @@ clean:
 cleanall: clean
 	@echo Deleting $(GEN_OBJC_DIR) $(TRANSLATE_LIST)
 	@rm -rf $(GEN_OBJC_DIR) $(TRANSLATE_LIST)
+
+install: default


### PR DESCRIPTION
fix bug of  "make: *** No rule to make target `install'. Stop. Command /usr/bin/make failed with exit code 2 " When Archive